### PR TITLE
ci: allow nightly installer to check if docker tag exists

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -63,7 +63,17 @@ jobs:
 
             # Get the tag name
             cat ./output.json
-            INSTALLER_VERSION=$(cat ./output.json | jq -r '.tags[0]')
+
+            # Check that the installer image exists
+            for i in $(jq -rc '.tags[]' < ./output.json); do
+              if ! docker pull "eu.gcr.io/gitpod-core-dev/build/installer:${i}"; then
+                echo "Installer tag doesn't exist ${i} - trying next one"
+              else
+                echo "Installer tag exists - ${i}"
+                INSTALLER_VERSION="${i}"
+                break
+              fi
+            done
           fi
 
           echo "installer_version=${INSTALLER_VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If there is no Installer image for the desired tag, it cycles through the available versions until it finds the tag in question

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

> If this requires testing on a new cloud provider, pull requests will only be accepted
if they come with an account for the platform in question so I can verify the work.
