### PR TITLE
chore: allow saving certs from gitpod variables

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -64,6 +64,20 @@ tasks:
     command: |
       gp sync-await setup
 
+      if [ -n "${CERTS_LIST}" ]; then
+        echo "Loading saved TLS certificates"
+        mkdir -p ./tmp/certs
+
+        echo $CERTS_LIST | base64 -d > ./tmp/cert-list.yaml
+
+        for k in $(cat ./tmp/cert-list.yaml | yq 'keys' -o json | jq -cr '.[] | @base64'); do
+          export domain=$(echo $k | base64 -d)
+          yq '.[env(domain)]' ./tmp/cert-list.yaml | base64 -d > ./tmp/certs/${domain}.yaml
+
+          unset domain
+        done
+      fi
+
 vscode:
   extensions:
     - donjayamanne.git-extension-pack


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This avoids having to find test certs to reload them. And avoids us being put in Lets Encrypt jail in develpment.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

> If this requires testing on a new cloud provider, pull requests will only be accepted
if they come with an account for the platform in question so I can verify the work.
