### PR TITLE
feat(cert-manager): allow installation of dns01 webhooks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,7 @@ cert_manager() {
   domain_name="${1}"
   secrets="${2}"
   cluster_issuer="${3}"
+  install_deps="${4}"
 
   helm upgrade \
     --atomic \
@@ -67,6 +68,14 @@ cert_manager() {
     --version ^1.11.0 \
     --wait \
     cert-manager cert-manager
+
+  if [ -n "${install_deps}" ]; then
+    echo "Executing cert-manager dependencies: ${install_deps}"
+
+    $install_deps
+
+    echo "Successfully executed ${install_deps}"
+  fi
 
   echo "Creating secrets for the ClusterIssuer"
 
@@ -268,7 +277,7 @@ stop_running_workspaces() {
 
 case "${cmd}" in
   cert_manager )
-    cert_manager "${DOMAIN_NAME:-$2}" "$(echo "${SECRETS:-$3}" | base64 -d)" "$(echo "${CLUSTER_ISSUER:-$4}" | base64 -d)"
+    cert_manager "${DOMAIN_NAME:-$2}" "$(echo "${SECRETS:-$3}" | base64 -d)" "$(echo "${CLUSTER_ISSUER:-$4}" | base64 -d)" "${WEBHOOKS_SCRIPT:-$5}"
     ;;
   install_gitpod )
     install_gitpod "$(echo "${GITPOD_CONFIG:-$2}" | base64 -d)" "$(echo "${GITPOD_SECRETS:-$3}" | base64 -d)"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add an optional stage after the installation of cert-manager that installs any [DNS01 webhooks](https://cert-manager.io/docs/configuration/acme/dns01/webhook/)

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Checklist

Thanks for this pull request. Please complete the checklist to get the change accepted quicker

### Cloud provider modules only
- [ ] This change requires testing on a new cloud provider
- [ ] I am prepared to share my cloud provider credentials (this is required for the change to be accepted - see [reasoning](https://github.com/mrsimonemms/gitpod-self-hosted#roadmap))
- [ ] My change follows the [standard provider interface](https://github.com/mrsimonemms/gitpod-self-hosted#provider-interfaces)
