### PR TITLE
fix(k3s): don't write the IP address to the kubeconfig file

### DIFF
--- a/infrastructure/modules/k3s/k3s.tf
+++ b/infrastructure/modules/k3s/k3s.tf
@@ -40,10 +40,11 @@ resource "ssh_sensitive_resource" "kubeconfig" {
   # Inspired by k3sup
   # @link https://github.com/alexellis/k3sup/blob/92c9c3a1ed17c6dc60327dc173dd9262894be76c/cmd/install.go#L564
   commands = [
-    "sudo sed -i \"s/127.0.0.1/${local.kubeconfig_address}/g\" ${local.k3s_kubeconfig}",
-    "sudo sed -i \"s/localhost/${local.kubeconfig_address}/g\" ${local.k3s_kubeconfig}",
-    "sudo sed -i \"s/default/${var.kubecontext}/g\" ${local.k3s_kubeconfig}",
-    "sudo cat ${local.k3s_kubeconfig}",
+    "sudo cp /etc/rancher/k3s/k3s.yaml /tmp/k3s.yaml",
+    "sudo sed -i \"s/127.0.0.1/${local.kubeconfig_address}/g\" /tmp/k3s.yaml",
+    "sudo sed -i \"s/localhost/${local.kubeconfig_address}/g\" /tmp/k3s.yaml",
+    "sudo sed -i \"s/default/${var.kubecontext}/g\" /tmp/k3s.yaml",
+    "sudo cat /tmp/k3s.yaml",
   ]
 }
 

--- a/infrastructure/modules/k3s/local.tf
+++ b/infrastructure/modules/k3s/local.tf
@@ -1,11 +1,10 @@
 locals {
   additional_managers        = [for id, node in var.managers : node if id > 0]
   primary_manager            = var.managers[0] # There must be at least one manager
-  k3s_kubeconfig             = "/etc/rancher/k3s/k3s.yaml"
   k3s_server_address_public  = var.load_balancer_address == null ? local.primary_manager.node.public_ip : var.load_balancer_address
   k3s_server_address_private = var.load_balancer_address == null ? local.primary_manager.node.private_ip : var.load_balancer_address # Load balancer always uses a public address
   k3s_token                  = chomp(ssh_sensitive_resource.k3s_token.result)
-  kubeconfig_address         = var.load_balancer_address != null ? var.load_balancer_address : lookup(local.primary_manager, "bastion_host", local.primary_manager.node.public_ip)
+  kubeconfig_address         = var.load_balancer_address != null ? var.load_balancer_address : (local.primary_manager.bastion_host != null ? local.primary_manager.bastion_host : local.primary_manager.node.public_ip)
   # https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-requirements/port-requirements#ports-for-rancher-server-nodes-on-k3s
   firewall_ports = [
     {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Previously, if the IP changed then the kubeconfig file wouldn't be updated. By keeping it with the default, it'll be correctly updated.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #53 

## How to test
<!-- Provide steps to test this PR -->

## Checklist

Thanks for this pull request. Please complete the checklist to get the change accepted quicker

- [ ] No merge commits please - use `git rebase upstream/main` instead

### Cloud provider modules only
- [ ] This change requires testing on a new cloud provider
- [ ] I am prepared to share my cloud provider credentials (this is required for the change to be accepted - see [reasoning](https://github.com/mrsimonemms/gitpod-self-hosted#roadmap))
- [ ] My change follows the [standard provider interface](https://github.com/mrsimonemms/gitpod-self-hosted#provider-interfaces)
