### PR TITLE
docs: archive the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # Gitpod Self-Hosted Instructions
 
+> Since Gitpod [enabled GitHub Actions by default](https://github.com/gitpod-io/gitpod/pull/16225)
+> it appears that the container images are no longer published to a publicly
+> accessible registry.
+>
+> **This means that the dream of maintaining Gitpod self-hosted is over**. I still
+> really hope that this decision is reversed, but I can't see it ever happening
+> now. If you do want to maintain a self-hosted development environment, there
+> are some strong projects in this space - in alphabetical order, some to investigate
+> are:
+>
+> * [Coder](https://coder.com)
+> * [Hocus](https://github.com/hocus-dev/hocus)
+>
+> Thanks to everyone who helped with this project, especially [Tom Barber](https://github.com/buggtb).
+> This is a very sad day indeed.
+>
+> Simon Emms, April 2023
+>
+> ![A sad day](https://media.giphy.com/media/2WxWfiavndgcM/giphy.gif)
+
+---
+
 Resources for managing your own [Gitpod](https://www.gitpod.io) installation
 
 <!-- toc -->


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This documents the change by Gitpod that the container image publishing location appears to have changed. As a result, this project is effectively dead.

Thanks to everyone, especially @buggtb, for their help in getting things this far.

So long, and thanks for all the fish!

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Checklist

Thanks for this pull request. Please complete the checklist to get the change accepted quicker

- [ ] No merge commits please - use `git rebase upstream/main` instead

### Cloud provider modules only
- [ ] This change requires testing on a new cloud provider
- [ ] I am prepared to share my cloud provider credentials (this is required for the change to be accepted - see [reasoning](https://github.com/mrsimonemms/gitpod-self-hosted#roadmap))
- [ ] My change follows the [standard provider interface](https://github.com/mrsimonemms/gitpod-self-hosted#provider-interfaces)
